### PR TITLE
fix(ci): unbreak spec-update workflow (EOF delimiter bug)

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -74,6 +74,7 @@ jobs:
             {
               echo 'DIFF_SUMMARY<<EOF'
               cat diff-summary.md
+              echo ''
               echo 'EOF'
             } >> $GITHUB_ENV
           fi

--- a/update/index.ts
+++ b/update/index.ts
@@ -89,7 +89,7 @@ async function run() {
     const summary = generateDiffSummary(oldSpec, spec);
     console.log("\nDiff summary:\n" + summary);
     if (process.env.CI) {
-      await Bun.write("diff-summary.md", summary);
+      await Bun.write("diff-summary.md", summary + "\n");
     }
   }
 


### PR DESCRIPTION
## Problem

The scheduled **Update Apple Spec** workflow has failed on every run for weeks (tracked in #30, ~60 failure comments). The workflow correctly detects new Apple spec versions (latest run found \`4.3 → 4.3.1\`) but crashes in the **Read diff summary** step:

```
##[error]Unable to process file command 'env' successfully.
##[error]Invalid value. Matching delimiter not found 'EOF'
```

## Cause

The step writes a multiline heredoc to \`$GITHUB_ENV\`:

```bash
echo 'DIFF_SUMMARY<<EOF'
cat diff-summary.md
echo 'EOF'
```

\`generateDiffSummary()\` returns a string with **no trailing newline**, and \`Bun.write\` writes it verbatim. So \`cat\` emits content not ending in \`\n\`, and \`echo 'EOF'\` is glued onto the last line — GitHub never sees \`EOF\` standalone, the job fails, and the failure-notification job spams #30.

Net effect: no auto-update PR has been created since this broke, so the published spec is stuck at 4.3 while Apple is at 4.3.1.

## Fix

- Emit an explicit blank line before the \`EOF\` delimiter in the workflow heredoc.
- Belt-and-suspenders: write \`diff-summary.md\` with a trailing newline.

Once merged, the next cron run should open the \`spec/update-v4.3.1\` PR and stop the failure comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)